### PR TITLE
Pass to eliminate init loops

### DIFF
--- a/mlir/include/CMakeLists.txt
+++ b/mlir/include/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Dialect)
 add_subdirectory(Conversion)
+add_subdirectory(Transform)

--- a/mlir/include/Transform/CMakeLists.txt
+++ b/mlir/include/Transform/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS TTLPasses.td)
+mlir_tablegen(TTLPasses.h.inc --gen-pass-decls)
+add_public_tablegen_target(MLIRTTLPassesIncGen)

--- a/mlir/include/Transform/TTLPasses.h
+++ b/mlir/include/Transform/TTLPasses.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Dialect/TTL/TTLDialect.h"
+#include "Dialect/TTL/TTLOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace ttl {
+#define GEN_PASS_DECL
+#include "Transform/TTLPasses.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "Transform/TTLPasses.h.inc"
+
+} // namespace ttl
+} // namespace mlir

--- a/mlir/include/Transform/TTLPasses.td
+++ b/mlir/include/Transform/TTLPasses.td
@@ -1,0 +1,16 @@
+#ifndef TTL_PASSES
+#define TTL_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def TTLEliminateInitLoops : Pass<"ttl-eliminate-init-loops", 
+                                  "::mlir::func::FuncOp"> {
+  let summary = "Replaces loops initializing empty tensors with a range init";
+
+  let statistics = [
+    Statistic<"numLoopsEliminated", "num-loops-eliminated", 
+                "Number of init loops eliminated">
+  ];
+}
+
+#endif // TTL_PASSES

--- a/mlir/lib/CMakeLists.txt
+++ b/mlir/lib/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Dialect)
 add_subdirectory(Conversion)
+add_subdirectory(Transform)

--- a/mlir/lib/Transform/CMakeLists.txt
+++ b/mlir/lib/Transform/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_mlir_library(TTLPasses
+  EliminateInitLoops.cpp
+
+  DEPENDS
+  MLIRTTLPassesIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRAnalysis
+  MLIRPass
+  )

--- a/mlir/lib/Transform/EliminateInitLoops.cpp
+++ b/mlir/lib/Transform/EliminateInitLoops.cpp
@@ -1,0 +1,126 @@
+#include "Transform/TTLPasses.h"
+#include <llvm/Support/Debug.h>
+
+namespace mlir {
+namespace ttl {
+#define GEN_PASS_DEF_TTLELIMINATEINITLOOPS
+#include "Transform/TTLPasses.h.inc"
+
+#define DEBUG_TYPE "ttl-eliminate-init-loops"
+
+namespace {
+
+class EliminateInitLoops
+    : public impl::TTLEliminateInitLoopsBase<EliminateInitLoops> {
+public:
+  using impl::TTLEliminateInitLoopsBase<
+      EliminateInitLoops>::TTLEliminateInitLoopsBase;
+
+  void runOnOperation() final {
+
+    func::FuncOp func = getOperation();
+    LLVM_DEBUG(llvm::dbgs() << "Function name: " << func.getName() << "\n");
+    func.walk([&](ttl::ForLoop forLoop) {
+      if (eliminateLoopIfPossible(forLoop)) {
+        ++numLoopsEliminated;
+      }
+    });
+  }
+
+private:
+  bool eliminateLoopIfPossible(ttl::ForLoop forLoop) {
+    // To eliminate an initialization loop, it must fulfill a number of
+    // conditions:
+
+    // 1. The loop must be directly in the function, i.e., not a nested loop or
+    // inside an `if`.
+    if (!isa<func::FuncOp>(forLoop->getParentOp())) {
+      LLVM_DEBUG(llvm::dbgs() << "Failed condition 1\n");
+      return false;
+    }
+
+    // 2. The loop's step must be a constant 1 and the start and end of the loop
+    // must be constants.
+    auto maybeConstantStep =
+        dyn_cast_or_null<ttl::IntConstant>(forLoop.getStep().getDefiningOp());
+    auto maybeConstantStart = dyn_cast_or_null<ttl::IntConstant>(
+        forLoop.getLowerBound().getDefiningOp());
+    auto maybeConstantEnd = dyn_cast_or_null<ttl::IntConstant>(
+        forLoop.getUpperBound().getDefiningOp());
+    if (!maybeConstantStep || maybeConstantStep.getConstVal() != 1 ||
+        !maybeConstantStart || !maybeConstantEnd) {
+      LLVM_DEBUG(llvm::dbgs() << "Failed condition 2\n");
+      return false;
+    }
+
+    auto tensorSize =
+        maybeConstantEnd.getConstVal() - maybeConstantStart.getConstVal();
+
+    // 3. The loop must return a single result of a 1-dimensional tensor and
+    // take a single init val of tensor type. The tensor must have static size
+    // and must match the range between the constant start and end of the loop.
+    if (forLoop.getNumResults() != 1 || forLoop.getInitArgs().size() != 1) {
+      LLVM_DEBUG(llvm::dbgs() << "Failed condition 3-1\n");
+      return false;
+    }
+    auto resultTy =
+        dyn_cast<ttl::TensorType>(forLoop.getResults().front().getType());
+    auto initArgTy =
+        dyn_cast<ttl::TensorType>(forLoop.getInitArgs().front().getType());
+    if (!resultTy || !initArgTy || resultTy.getShape().size() != 1 ||
+        resultTy != initArgTy || resultTy.getShape().front() != tensorSize) {
+      LLVM_DEBUG(llvm::dbgs() << "Failed condition 3-2\n");
+      return false;
+    }
+
+    // 4. The init val of the loop must be a TensorEmpty which only has a single
+    // user (the loop).
+    auto maybeTensorEmpty = dyn_cast<ttl::TensorEmpty>(
+        forLoop.getInitArgs().front().getDefiningOp());
+    if (!maybeTensorEmpty || !maybeTensorEmpty.getTensor().hasOneUse()) {
+      LLVM_DEBUG(llvm::dbgs() << "Failed condition 4\n");
+      return false;
+    }
+
+    // 5. The loop's body must consist of two operations, with the first one
+    // being a TensorInsert (the other is the terminator/Yield) that takes a
+    // single index.
+    Block *bodyBlock = forLoop.getBody();
+    if (bodyBlock->getOperations().size() != 2) {
+      LLVM_DEBUG(llvm::dbgs() << "Failed condition 5-1\n");
+      return false;
+    }
+    auto maybeTensorInsert = dyn_cast<ttl::TensorInsert>(bodyBlock->front());
+    if (!maybeTensorInsert || maybeTensorInsert.getIndices().size() != 1) {
+      LLVM_DEBUG(llvm::dbgs() << "Failed condition 5-2\n");
+      return false;
+    }
+
+    // 6. The body block must have two arguments (one for the iteration
+    // variable, one for the loop-carried tensor) and the tensor insert must use
+    // them.
+    if (bodyBlock->getNumArguments() != 2 ||
+        bodyBlock->getArgument(0) != maybeTensorInsert.getIndices().front() ||
+        bodyBlock->getArgument(0) != maybeTensorInsert.getValue() ||
+        bodyBlock->getArgument(1) != maybeTensorInsert.getDest()) {
+      LLVM_DEBUG(llvm::dbgs() << "Failed condition 6\n");
+      return false;
+    }
+
+    // Our candidate fulfills all conditions, so we are going to perform the
+    // transformation:
+    // 1. Replace the loop with a TensorRangeInit.
+    // 2. Erase the original TensorEmpty.
+    IRRewriter rewriter(forLoop);
+    rewriter.replaceOpWithNewOp<ttl::TensorRangeInit>(
+        forLoop, forLoop.getResultTypes().front(), forLoop.getLowerBound(),
+        forLoop.getUpperBound());
+    rewriter.eraseOp(maybeTensorEmpty);
+
+    return true;
+  }
+};
+
+} // namespace
+} // namespace ttl
+} // namespace mlir

--- a/mlir/tools/ttl-opt/CMakeLists.txt
+++ b/mlir/tools/ttl-opt/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBS
         TTLToTensor
         TTLToLinalg
         TTLToScalar
+        TTLPasses
         MLIRFuncInlinerExtension
         )
 add_llvm_executable(ttl-opt ttl-opt.cpp)

--- a/mlir/tools/ttl-opt/ttl-opt.cpp
+++ b/mlir/tools/ttl-opt/ttl-opt.cpp
@@ -1,6 +1,8 @@
 
 #include "Conversion/Passes.h"
 #include "Dialect/TTL/TTLDialect.h"
+#include "Transform/TTLPasses.h"
+#include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/InitAllDialects.h"
@@ -13,11 +15,11 @@
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
-#include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 
 int main(int argc, char **argv) {
   // Register passes, including TTL conversion passes.
   mlir::registerAllPasses();
+  mlir::ttl::registerTTLEliminateInitLoops();
   mlir::ttl::registerTTLToTensor();
   mlir::ttl::registerTTLToLinalg();
   mlir::ttl::registerTTLToScalar();

--- a/test/Transform/EliminateInitLoops/init-loop.mlir
+++ b/test/Transform/EliminateInitLoops/init-loop.mlir
@@ -1,0 +1,226 @@
+// RUN: ttl-opt --ttl-eliminate-init-loops %s | FileCheck %s
+
+func.func @tensor_func(%arg0: !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int> {
+  "ttl.return"(%arg0) : (!ttl.tensor<8x!ttl.int>) -> ()
+}
+func.func @int_passthrough(%arg0: !ttl.int) -> !ttl.int {
+  "ttl.return"(%arg0) : (!ttl.int) -> ()
+}
+
+
+// COM: An init loop that gets replaced successfully
+// CHECK-LABEL:   func.func @init_loop1() -> !ttl.tensor<8x!ttl.int> {
+// CHECK:           %[[VAL_0:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_1:.*]] = ttl.const_int 8
+// CHECK:           %[[VAL_2:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_3:.*]] = ttl.const_int 1
+// CHECK:           %[[VAL_4:.*]] = "ttl.tensor_range_init"(%[[VAL_0]], %[[VAL_1]]) : (!ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+// CHECK:           "ttl.return"(%[[VAL_4]]) : (!ttl.tensor<8x!ttl.int>) -> ()
+func.func @init_loop1() -> !ttl.tensor<8x!ttl.int> {
+  %0 = ttl.const_int 0
+  %1 = ttl.const_int 8
+  %2 = "ttl.tensor_empty"() : () -> !ttl.tensor<8x!ttl.int>
+  %3 = ttl.const_int 0
+  %4 = ttl.const_int 1
+  %5 = "ttl.for"(%0, %1, %4, %2) ({
+  ^bb0(%arg0: !ttl.int, %arg1: !ttl.tensor<8x!ttl.int>):
+    %6 = "ttl.tensor_insert"(%arg1, %arg0, %arg0) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+    "ttl.yield"(%6) : (!ttl.tensor<8x!ttl.int>) -> ()
+  }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+  "ttl.return"(%5) : (!ttl.tensor<8x!ttl.int>) -> ()
+}
+
+// COM: An init loop that gets replaced, but has a non-zero lower bound.
+// CHECK-LABEL:   func.func @init_loop2() -> !ttl.tensor<8x!ttl.int> {
+// CHECK:           %[[VAL_0:.*]] = ttl.const_int 4
+// CHECK:           %[[VAL_1:.*]] = ttl.const_int 12
+// CHECK:           %[[VAL_2:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_3:.*]] = ttl.const_int 1
+// CHECK:           %[[VAL_4:.*]] = "ttl.tensor_range_init"(%[[VAL_0]], %[[VAL_1]]) : (!ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+// CHECK:           "ttl.return"(%[[VAL_4]]) : (!ttl.tensor<8x!ttl.int>) -> ()
+// CHECK:         }
+func.func @init_loop2() -> !ttl.tensor<8x!ttl.int> {
+  %0 = ttl.const_int 4
+  %1 = ttl.const_int 12
+  %2 = "ttl.tensor_empty"() : () -> !ttl.tensor<8x!ttl.int>
+  %3 = ttl.const_int 0
+  %4 = ttl.const_int 1
+  %5 = "ttl.for"(%0, %1, %4, %2) ({
+  ^bb0(%arg0: !ttl.int, %arg1: !ttl.tensor<8x!ttl.int>):
+    %6 = "ttl.tensor_insert"(%arg1, %arg0, %arg0) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+    "ttl.yield"(%6) : (!ttl.tensor<8x!ttl.int>) -> ()
+  }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+  "ttl.return"(%5) : (!ttl.tensor<8x!ttl.int>) -> ()
+}
+
+// COM: An example that fails because the loop bounds are not constant.
+// CHECK-LABEL:   func.func @init_loop3(
+// CHECK-SAME:      %[[VAL_0:.*]]: !ttl.int,
+// CHECK-SAME:      %[[VAL_1:.*]]: !ttl.int) -> !ttl.tensor<8x!ttl.int> {
+// CHECK:           %[[VAL_2:.*]] = "ttl.tensor_empty"() : () -> !ttl.tensor<8x!ttl.int>
+// CHECK:           %[[VAL_3:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_4:.*]] = ttl.const_int 1
+// CHECK:           %[[VAL_5:.*]] = "ttl.for"(%[[VAL_0]], %[[VAL_1]], %[[VAL_4]], %[[VAL_2]]) ({
+// CHECK:           ^bb0(%[[VAL_6:.*]]: !ttl.int, %[[VAL_7:.*]]: !ttl.tensor<8x!ttl.int>):
+// CHECK:             %[[VAL_8:.*]] = "ttl.tensor_insert"(%[[VAL_7]], %[[VAL_6]], %[[VAL_6]]) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+// CHECK:             "ttl.yield"(%[[VAL_8]]) : (!ttl.tensor<8x!ttl.int>) -> ()
+// CHECK:           }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+// CHECK:           "ttl.return"(%[[VAL_5]]) : (!ttl.tensor<8x!ttl.int>) -> ()
+// CHECK:         }
+
+
+func.func @init_loop3(%arg0: !ttl.int, %arg1: !ttl.int) -> !ttl.tensor<8x!ttl.int> {
+  %0 = "ttl.tensor_empty"() : () -> !ttl.tensor<8x!ttl.int>
+  %1 = ttl.const_int 0
+  %2 = ttl.const_int 1
+  %3 = "ttl.for"(%arg0, %arg1, %2, %0) ({
+  ^bb0(%arg2: !ttl.int, %arg3: !ttl.tensor<8x!ttl.int>):
+    %4 = "ttl.tensor_insert"(%arg3, %arg2, %arg2) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+    "ttl.yield"(%4) : (!ttl.tensor<8x!ttl.int>) -> ()
+  }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+  "ttl.return"(%3) : (!ttl.tensor<8x!ttl.int>) -> ()
+}
+
+// COM: An example that fails because the tensor is multi-dimensional.
+// CHECK-LABEL:   func.func @init_loop4() -> !ttl.tensor<2x4x!ttl.int> {
+// CHECK:           %[[VAL_0:.*]] = ttl.const_int 4
+// CHECK:           %[[VAL_1:.*]] = ttl.const_int 12
+// CHECK:           %[[VAL_2:.*]] = "ttl.tensor_empty"() : () -> !ttl.tensor<2x4x!ttl.int>
+// CHECK:           %[[VAL_3:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_4:.*]] = ttl.const_int 1
+// CHECK:           %[[VAL_5:.*]] = "ttl.for"(%[[VAL_0]], %[[VAL_1]], %[[VAL_4]], %[[VAL_2]]) ({
+// CHECK:           ^bb0(%[[VAL_6:.*]]: !ttl.int, %[[VAL_7:.*]]: !ttl.tensor<2x4x!ttl.int>):
+// CHECK:             %[[VAL_8:.*]] = "ttl.tensor_insert"(%[[VAL_7]], %[[VAL_6]], %[[VAL_6]]) : (!ttl.tensor<2x4x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<2x4x!ttl.int>
+// CHECK:             "ttl.yield"(%[[VAL_8]]) : (!ttl.tensor<2x4x!ttl.int>) -> ()
+// CHECK:           }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<2x4x!ttl.int>) -> !ttl.tensor<2x4x!ttl.int>
+// CHECK:           "ttl.return"(%[[VAL_5]]) : (!ttl.tensor<2x4x!ttl.int>) -> ()
+func.func @init_loop4() -> !ttl.tensor<2x4x!ttl.int> {
+  %0 = ttl.const_int 4
+  %1 = ttl.const_int 12
+  %2 = "ttl.tensor_empty"() : () -> !ttl.tensor<2x4x!ttl.int>
+  %3 = ttl.const_int 0
+  %4 = ttl.const_int 1
+  %5 = "ttl.for"(%0, %1, %4, %2) ({
+  ^bb0(%arg0: !ttl.int, %arg1: !ttl.tensor<2x4x!ttl.int>):
+    %6 = "ttl.tensor_insert"(%arg1, %arg0, %arg0) : (!ttl.tensor<2x4x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<2x4x!ttl.int>
+    "ttl.yield"(%6) : (!ttl.tensor<2x4x!ttl.int>) -> ()
+  }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<2x4x!ttl.int>) -> !ttl.tensor<2x4x!ttl.int>
+  "ttl.return"(%5) : (!ttl.tensor<2x4x!ttl.int>) -> ()
+}
+
+// COM: An example that fails because there's another user of the TensorEmpty.
+// CHECK-LABEL:   func.func @init_loop5() -> !ttl.tensor<8x!ttl.int> {
+// CHECK:           %[[VAL_0:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_1:.*]] = ttl.const_int 8
+// CHECK:           %[[VAL_2:.*]] = "ttl.tensor_empty"() : () -> !ttl.tensor<8x!ttl.int>
+// CHECK:           %[[VAL_3:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_4:.*]] = call @tensor_func(%[[VAL_2]]) : (!ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+// CHECK:           %[[VAL_5:.*]] = ttl.const_int 1
+// CHECK:           %[[VAL_6:.*]] = "ttl.for"(%[[VAL_0]], %[[VAL_1]], %[[VAL_5]], %[[VAL_2]]) ({
+// CHECK:           ^bb0(%[[VAL_7:.*]]: !ttl.int, %[[VAL_8:.*]]: !ttl.tensor<8x!ttl.int>):
+// CHECK:             %[[VAL_9:.*]] = "ttl.tensor_insert"(%[[VAL_8]], %[[VAL_7]], %[[VAL_7]]) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+// CHECK:             "ttl.yield"(%[[VAL_9]]) : (!ttl.tensor<8x!ttl.int>) -> ()
+// CHECK:           }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+// CHECK:           "ttl.return"(%[[VAL_6]]) : (!ttl.tensor<8x!ttl.int>) -> ()
+func.func @init_loop5() -> !ttl.tensor<8x!ttl.int> {
+  %0 = ttl.const_int 0
+  %1 = ttl.const_int 8
+  %2 = "ttl.tensor_empty"() : () -> !ttl.tensor<8x!ttl.int>
+  %3 = ttl.const_int 0
+  %4 = call @tensor_func(%2) : (!ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+  %5 = ttl.const_int 1
+  %6 = "ttl.for"(%0, %1, %5, %2) ({
+  ^bb0(%arg0: !ttl.int, %arg1: !ttl.tensor<8x!ttl.int>):
+    %7 = "ttl.tensor_insert"(%arg1, %arg0, %arg0) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+    "ttl.yield"(%7) : (!ttl.tensor<8x!ttl.int>) -> ()
+  }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+  "ttl.return"(%6) : (!ttl.tensor<8x!ttl.int>) -> ()
+}
+
+// COM: An example that fails because there's another operation in the loop body.
+// CHECK-LABEL:   func.func @init_loop6() -> !ttl.tensor<8x!ttl.int> {
+// CHECK:           %[[VAL_0:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_1:.*]] = ttl.const_int 8
+// CHECK:           %[[VAL_2:.*]] = "ttl.tensor_empty"() : () -> !ttl.tensor<8x!ttl.int>
+// CHECK:           %[[VAL_3:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_4:.*]] = ttl.const_int 1
+// CHECK:           %[[VAL_5:.*]] = "ttl.for"(%[[VAL_0]], %[[VAL_1]], %[[VAL_4]], %[[VAL_2]]) ({
+// CHECK:           ^bb0(%[[VAL_6:.*]]: !ttl.int, %[[VAL_7:.*]]: !ttl.tensor<8x!ttl.int>):
+// CHECK:             %[[VAL_8:.*]] = func.call @int_passthrough(%[[VAL_6]]) : (!ttl.int) -> !ttl.int
+// CHECK:             %[[VAL_9:.*]] = "ttl.tensor_insert"(%[[VAL_7]], %[[VAL_6]], %[[VAL_6]]) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+// CHECK:             "ttl.yield"(%[[VAL_9]]) : (!ttl.tensor<8x!ttl.int>) -> ()
+// CHECK:           }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+// CHECK:           "ttl.return"(%[[VAL_5]]) : (!ttl.tensor<8x!ttl.int>) -> ()
+func.func @init_loop6() -> !ttl.tensor<8x!ttl.int> {
+  %0 = ttl.const_int 0
+  %1 = ttl.const_int 8
+  %2 = "ttl.tensor_empty"() : () -> !ttl.tensor<8x!ttl.int>
+  %3 = ttl.const_int 0
+  %4 = ttl.const_int 1
+  %5 = "ttl.for"(%0, %1, %4, %2) ({
+  ^bb0(%arg0: !ttl.int, %arg1: !ttl.tensor<8x!ttl.int>):
+    %6 = func.call @int_passthrough(%arg0) : (!ttl.int) -> !ttl.int
+    %7 = "ttl.tensor_insert"(%arg1, %arg0, %arg0) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+    "ttl.yield"(%7) : (!ttl.tensor<8x!ttl.int>) -> ()
+  }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+  "ttl.return"(%5) : (!ttl.tensor<8x!ttl.int>) -> ()
+}
+
+// COM: An example that fails because the inserted value is not the loop induction var.
+// CHECK-LABEL:   func.func @init_loop7() -> !ttl.tensor<8x!ttl.int> {
+// CHECK:           %[[VAL_0:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_1:.*]] = ttl.const_int 8
+// CHECK:           %[[VAL_2:.*]] = "ttl.tensor_empty"() : () -> !ttl.tensor<8x!ttl.int>
+// CHECK:           %[[VAL_3:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_4:.*]] = ttl.const_int 1
+// CHECK:           %[[VAL_5:.*]] = "ttl.for"(%[[VAL_0]], %[[VAL_1]], %[[VAL_4]], %[[VAL_2]]) ({
+// CHECK:           ^bb0(%[[VAL_6:.*]]: !ttl.int, %[[VAL_7:.*]]: !ttl.tensor<8x!ttl.int>):
+// CHECK:             %[[VAL_8:.*]] = func.call @int_passthrough(%[[VAL_6]]) : (!ttl.int) -> !ttl.int
+// CHECK:             %[[VAL_9:.*]] = "ttl.tensor_insert"(%[[VAL_7]], %[[VAL_8]], %[[VAL_6]]) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+// CHECK:             "ttl.yield"(%[[VAL_9]]) : (!ttl.tensor<8x!ttl.int>) -> ()
+// CHECK:           }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+// CHECK:           "ttl.return"(%[[VAL_5]]) : (!ttl.tensor<8x!ttl.int>) -> ()
+func.func @init_loop7() -> !ttl.tensor<8x!ttl.int> {
+  %0 = ttl.const_int 0
+  %1 = ttl.const_int 8
+  %2 = "ttl.tensor_empty"() : () -> !ttl.tensor<8x!ttl.int>
+  %3 = ttl.const_int 0
+  %4 = ttl.const_int 1
+  %5 = "ttl.for"(%0, %1, %4, %2) ({
+  ^bb0(%arg0: !ttl.int, %arg1: !ttl.tensor<8x!ttl.int>):
+    %6 = func.call @int_passthrough(%arg0) : (!ttl.int) -> !ttl.int
+    %7 = "ttl.tensor_insert"(%arg1, %6, %arg0) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+    "ttl.yield"(%7) : (!ttl.tensor<8x!ttl.int>) -> ()
+  }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+  "ttl.return"(%5) : (!ttl.tensor<8x!ttl.int>) -> ()
+}
+
+// COM: An example that fails because the index is not the loop induction var.
+// CHECK-LABEL:   func.func @init_loop8() -> !ttl.tensor<8x!ttl.int> {
+// CHECK:           %[[VAL_0:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_1:.*]] = ttl.const_int 8
+// CHECK:           %[[VAL_2:.*]] = "ttl.tensor_empty"() : () -> !ttl.tensor<8x!ttl.int>
+// CHECK:           %[[VAL_3:.*]] = ttl.const_int 0
+// CHECK:           %[[VAL_4:.*]] = ttl.const_int 1
+// CHECK:           %[[VAL_5:.*]] = "ttl.for"(%[[VAL_0]], %[[VAL_1]], %[[VAL_4]], %[[VAL_2]]) ({
+// CHECK:           ^bb0(%[[VAL_6:.*]]: !ttl.int, %[[VAL_7:.*]]: !ttl.tensor<8x!ttl.int>):
+// CHECK:             %[[VAL_8:.*]] = func.call @int_passthrough(%[[VAL_6]]) : (!ttl.int) -> !ttl.int
+// CHECK:             %[[VAL_9:.*]] = "ttl.tensor_insert"(%[[VAL_7]], %[[VAL_6]], %[[VAL_8]]) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+// CHECK:             "ttl.yield"(%[[VAL_9]]) : (!ttl.tensor<8x!ttl.int>) -> ()
+// CHECK:           }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+// CHECK:           "ttl.return"(%[[VAL_5]]) : (!ttl.tensor<8x!ttl.int>) -> ()
+func.func @init_loop8() -> !ttl.tensor<8x!ttl.int> {
+  %0 = ttl.const_int 0
+  %1 = ttl.const_int 8
+  %2 = "ttl.tensor_empty"() : () -> !ttl.tensor<8x!ttl.int>
+  %3 = ttl.const_int 0
+  %4 = ttl.const_int 1
+  %5 = "ttl.for"(%0, %1, %4, %2) ({
+  ^bb0(%arg0: !ttl.int, %arg1: !ttl.tensor<8x!ttl.int>):
+    %6 = func.call @int_passthrough(%arg0) : (!ttl.int) -> !ttl.int
+    %7 = "ttl.tensor_insert"(%arg1, %arg0, %6) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
+    "ttl.yield"(%7) : (!ttl.tensor<8x!ttl.int>) -> ()
+  }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+  "ttl.return"(%5) : (!ttl.tensor<8x!ttl.int>) -> ()
+}
+

--- a/test/Transform/EliminateInitLoops/init-loop.mlir
+++ b/test/Transform/EliminateInitLoops/init-loop.mlir
@@ -108,7 +108,7 @@ func.func @init_loop4() -> !ttl.tensor<2x4x!ttl.int> {
   "ttl.return"(%5) : (!ttl.tensor<2x4x!ttl.int>) -> ()
 }
 
-// COM: An example that fails because there's another user of the TensorEmpty.
+// COM: A loop that gets removed, while the other use continues to use the original TensorEmpty.
 // CHECK-LABEL:   func.func @init_loop5() -> !ttl.tensor<8x!ttl.int> {
 // CHECK:           %[[VAL_0:.*]] = ttl.const_int 0
 // CHECK:           %[[VAL_1:.*]] = ttl.const_int 8
@@ -116,11 +116,7 @@ func.func @init_loop4() -> !ttl.tensor<2x4x!ttl.int> {
 // CHECK:           %[[VAL_3:.*]] = ttl.const_int 0
 // CHECK:           %[[VAL_4:.*]] = call @tensor_func(%[[VAL_2]]) : (!ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
 // CHECK:           %[[VAL_5:.*]] = ttl.const_int 1
-// CHECK:           %[[VAL_6:.*]] = "ttl.for"(%[[VAL_0]], %[[VAL_1]], %[[VAL_5]], %[[VAL_2]]) ({
-// CHECK:           ^bb0(%[[VAL_7:.*]]: !ttl.int, %[[VAL_8:.*]]: !ttl.tensor<8x!ttl.int>):
-// CHECK:             %[[VAL_9:.*]] = "ttl.tensor_insert"(%[[VAL_8]], %[[VAL_7]], %[[VAL_7]]) : (!ttl.tensor<8x!ttl.int>, !ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
-// CHECK:             "ttl.yield"(%[[VAL_9]]) : (!ttl.tensor<8x!ttl.int>) -> ()
-// CHECK:           }) : (!ttl.int, !ttl.int, !ttl.int, !ttl.tensor<8x!ttl.int>) -> !ttl.tensor<8x!ttl.int>
+// CHECK:           %[[VAL_6:.*]] = "ttl.tensor_range_init"(%[[VAL_0]], %[[VAL_1]]) : (!ttl.int, !ttl.int) -> !ttl.tensor<8x!ttl.int>
 // CHECK:           "ttl.return"(%[[VAL_6]]) : (!ttl.tensor<8x!ttl.int>) -> ()
 func.func @init_loop5() -> !ttl.tensor<8x!ttl.int> {
   %0 = ttl.const_int 0


### PR DESCRIPTION
An example of a simple transformation pass that doesn't use patterns, but a more "classic" walk across the IR.

The purpose of the pass is to eliminate `for`-loops that initialize an empty tensor with the loop induction value in every iteration and can be replaced by a tensor range initialization under a number of conditions.

The pass also defines a debugging type and a pass statistic counting the number of loops eliminated.